### PR TITLE
Added cache for creative inventory network data

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -110,6 +110,7 @@ use pocketmine\network\mcpe\protocol\DataPacket;
 use pocketmine\network\mcpe\protocol\DisconnectPacket;
 use pocketmine\network\mcpe\protocol\EntityEventPacket;
 use pocketmine\network\mcpe\protocol\InteractPacket;
+use pocketmine\network\mcpe\protocol\InventoryContentPacket;
 use pocketmine\network\mcpe\protocol\InventoryTransactionPacket;
 use pocketmine\network\mcpe\protocol\ItemFrameDropItemPacket;
 use pocketmine\network\mcpe\protocol\LevelEventPacket;
@@ -1319,7 +1320,7 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 		}
 
 		$this->sendSettings();
-		$this->inventory->sendCreativeContents();
+		$this->sendCreativeInventory();
 
 		return true;
 	}
@@ -2075,11 +2076,23 @@ class Player extends Human implements CommandSender, ChunkLoader, IPlayer{
 
 		$this->inventory->sendContents($this);
 		$this->inventory->sendArmorContents($this);
-		$this->inventory->sendCreativeContents();
+		$this->sendCreativeInventory();
 		$this->inventory->sendHeldItem($this);
 
 		$this->server->addOnlinePlayer($this);
 		$this->server->onPlayerCompleteLoginSequence($this);
+	}
+
+	private function sendCreativeInventory() : void{
+		if(!$this->isSpectator()){
+			$this->dataPacket(Item::getCreativeInventoryPacket());
+		}else{
+			$pk = new InventoryContentPacket();
+			$pk->windowId = ContainerIds::CREATIVE;
+			$pk->items = [];
+
+			$this->dataPacket($pk);
+		}
 	}
 
 	/**

--- a/src/pocketmine/inventory/PlayerInventory.php
+++ b/src/pocketmine/inventory/PlayerInventory.php
@@ -379,19 +379,6 @@ class PlayerInventory extends EntityInventory{
 		}
 	}
 
-	public function sendCreativeContents(){
-		$pk = new InventoryContentPacket();
-		$pk->windowId = ContainerIds::CREATIVE;
-
-		if(!$this->getHolder()->isSpectator()){ //fill it for all gamemodes except spectator
-			foreach(Item::getCreativeItems() as $i => $item){
-				$pk->items[$i] = clone $item;
-			}
-		}
-
-		$this->getHolder()->dataPacket($pk);
-	}
-
 	/**
 	 * This override is here for documentation and code completion purposes only.
 	 * @return Human|Player


### PR DESCRIPTION
This is expensive to encode, and is created on the fly on every player join and gamemode change. This is wasteful and unnecessary.

## Introduction
<!-- Explain existing problems or why this pull request is necessary -->

### Relevant issues
<!-- List relevant issues here -->
<!--

* Fixes #1
* Fixes #2

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
